### PR TITLE
setting stop event after replay camera finishes sending frames

### DIFF
--- a/src/robothub/replay/replay_camera.py
+++ b/src/robothub/replay/replay_camera.py
@@ -301,6 +301,7 @@ class ColorReplayCamera(ReplayCamera):
             time.sleep(time_to_sleep)
 
         self._capture_manager.close()
+        self._stop_event.set()
 
     def start_polling(self, device: dai.Device):
         self._thread = threading.Thread(target=self._send_video_frames, args=(device,))
@@ -715,6 +716,7 @@ class MonoReplayCamera(ReplayCamera):
             time.sleep(time_to_sleep)
 
         self._capture_manager.close()
+        self._stop_event.set()
 
     def start_polling(self, device: dai.Device):
         thread = threading.Thread(target=self._send_video_frames, args=(device,))


### PR DESCRIPTION
When `run_in_loop` is set to False and the ReplayCamera finishes sending frames, it must signal to the user that it has finished. Setting the `_stop_event` makes sense.