### PR TITLE
Add passthrough of metadata in save_video_event for frame_buffer and live_view

### DIFF
--- a/src/robothub/frame_buffer.py
+++ b/src/robothub/frame_buffer.py
@@ -88,7 +88,8 @@ class FrameBuffer:
                          frame_width: int,
                          frame_height: int,
                          on_complete: Optional[Callable] = None,
-                         delete_after_complete: bool = False
+                         delete_after_complete: bool = False,
+                         metadata: Optional[dict] = None,
                          ) -> threading.Thread:
         """
         Saves a video event to the frame buffer, then calls `on_complete` when the video is ready.
@@ -107,7 +108,7 @@ class FrameBuffer:
         """
 
         def on_complete_default(video_path):
-            send_video_event(video_path, title)
+            send_video_event(video_path, title, metadata)
 
         if on_complete is None:
             on_complete = on_complete_default

--- a/src/robothub/live_view.py
+++ b/src/robothub/live_view.py
@@ -429,6 +429,7 @@ class SdkLiveView(LiveView):
                          before_seconds: int,
                          after_seconds: int,
                          title: str,
+                         metadata: Optional[dict] = None,
                          ) -> None:
         """
         Saves a video event to the frame buffer, then calls `on_complete` when the video is ready.
@@ -445,7 +446,7 @@ class SdkLiveView(LiveView):
 
         # We need to start a new thread because we cannot block the main thread.
         def on_complete(video_path):
-            send_video_event(video_path, title)
+            send_video_event(video_path, title, metadata)
 
         kwargs = {
             'before_seconds': before_seconds,


### PR DESCRIPTION
Allows a user to use the nicer `save_video_event` over separate `_save_video` and `send_video_event` calls to enable metadata to be send to the RobotHub. Works by having an optional argument `metadata` in the frame_buffer/live_view method that gets pass through to the events handler.